### PR TITLE
Automatically Add Quotes (") Around Env Lines With Incompatible Chars

### DIFF
--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -78,7 +78,11 @@ services:
 {% endif %}
 {% if container.environment is defined %}
 {% for env_var in container.environment %}
+{% if ":" in env_var %}
+      - "{{ env_var }}"
+{% else %}
       - {{ env_var }}
+{% endif %}
 {% endfor %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
An env var with a value that contains a `:` character can sometimes be invalid and not start properly:

```
$ docker-compose up -d
validating /opt/docker/my_container/docker-compose.yml: services.foobar.environment.0 must be a string
```

**Broken:**
```
---
services:
  foobar:
    image: foo/bar:latest
    container_name: foobar
    environment:
      - BLA_BLA=Blabla :: Biz Baz
      - THIS_IS=a test
```

**Fixed:**
```
---
services:
  foobar:
    image: foo/bar:latest
    container_name: foobar
    environment:
      - "BLA_BLA=Blabla :: Biz Baz"
      - THIS_IS=a test
```